### PR TITLE
Custom error messages, removed rails dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea
 *.sublime-*

--- a/daft_cc_validator.gemspec
+++ b/daft_cc_validator.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = DaftCcValidator::VERSION
   spec.authors       = ["Piotr Kruczek", "Jacek Zachariasz", "Jan Grodowski", "Patryk Pastewski"]
   spec.email         = ["daftcode@daftcode.pl"]
-  spec.summary       = %q{Credit card validation with all dependant files}
+  spec.summary       = %q{Credit card validation with all dependant fields}
   spec.description   = %q{Such desc}
   spec.homepage      = ""
   spec.license       = "MIT"

--- a/daft_cc_validator.gemspec
+++ b/daft_cc_validator.gemspec
@@ -6,9 +6,9 @@ require 'daft_cc_validator/version'
 Gem::Specification.new do |spec|
   spec.name          = "daft_cc_validator"
   spec.version       = DaftCcValidator::VERSION
-  spec.authors       = ["Piotr Kruczek", "Jacek Zachariasz", "Jan Grodowski"]
+  spec.authors       = ["Piotr Kruczek", "Jacek Zachariasz", "Jan Grodowski", "Patryk Pastewski"]
   spec.email         = ["daftcode@daftcode.pl"]
-  spec.summary       = %q{Credit card validation with all dependant fileds}
+  spec.summary       = %q{Credit card validation with all dependant files}
   spec.description   = %q{Such desc}
   spec.homepage      = ""
   spec.license       = "MIT"
@@ -18,9 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activemodel"
+  spec.add_dependency "monads"
+
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency "rails"
 end

--- a/lib/daft_cc_validator/railtie.rb
+++ b/lib/daft_cc_validator/railtie.rb
@@ -1,9 +1,0 @@
-module DaftCcValidator
-  class Railtie < Rails::Railtie
-    # initializer 'daft_cc_validator.initialize' do
-    #   ActiveSupport.on_load(:active_model) do
-    #     ActiveModel::Validations.send :include, DaftCcValidator
-    #   end
-    # end
-  end
-end

--- a/spec/dummy/user.rb
+++ b/spec/dummy/user.rb
@@ -6,9 +6,13 @@ class User
   attr_accessor  :credit_card_number, :credit_card_cvv, :credit_card_month,
     :credit_card_year, :credit_card_owner
 
-  validate_credit_card_fields  number: :credit_card_number, cvv: :credit_card_cvv, month: :credit_card_month,
-    year: :credit_card_year, owner: :credit_card_owner, providers: [:amex, :visa]
-  
+  validate_credit_card_fields  number: :credit_card_number,
+                               cvv: :credit_card_cvv,
+                               month: { field: :credit_card_month },
+                               year: :credit_card_year,
+                               owner: :credit_card_owner,
+                               providers: [:amex, :visa]
+
   def [](key)
     send(key)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'bundler/setup'
 Bundler.setup
 
-require 'rails'
+require 'active_model'
 require 'active_model'
 require 'byebug'
 require 'daft_cc_validator'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,9 @@ require 'bundler/setup'
 Bundler.setup
 
 require 'active_model'
-require 'active_model'
 require 'byebug'
 require 'daft_cc_validator'
 require 'dummy/user'
-
-# require 'daft_cc_validator_spec' # and any other gems you need
 
 RSpec.configure do |config|
   # some (optional) config here


### PR DESCRIPTION
Zmieniłem dependency z Rails na ActiveModel, bo tylko tyle wystarczy do validacji.
Brak ActiveSupport wymusił kilka małych zmian w kodzie, ale przynajmniej jest dużo lżej i można używać tego np. na Sinatrze.

Dodatkowo dodałem opcję konfiguracji custom error messages i defaultowe nazwy pól. 
Przykładowy syntax w modelu:
```
validate_credit_card_fields  number: :credit_card_number,
                             cvv: { field: :custom_cvv_field, blank: 'cvv is blank', invalid: 'cvv is invalid' },
                             month: { field: :credit_card_month }
                             providers: [:amex, :visa]
```

Sprawdźcie czy nic nie popsułem ;) *(u mnie działa)* 